### PR TITLE
CI: Implement secrets google in ci python

### DIFF
--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -11,7 +11,11 @@ on:
         type: string
         required: false
         default: "['3.7', '3.11']"
-
+    secrets:
+      GOOGLE_CREDENTIALS:
+        required: false
+      GOOGLE_TOKEN:
+        required: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -16,6 +16,10 @@ on:
         required: false
       GOOGLE_TOKEN:
         required: false
+env:
+  # Google Credentials
+  GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
+  GOOGLE_TOKEN: ${{ secrets.GOOGLE_TOKEN }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
To make it possible to use the CI workflow for Python for plugin projects involving Google, it is necessary to implement two secrets:

- GOOGLE_CREDENTIALS
- GOOGLE_TOKEN

To keep the workflow for other users, secrets are optional.