### PR TITLE
MNT: Update the PyPI Upload action version to release/v1.

### DIFF
--- a/.github/workflows/python_pypi_upload.yml
+++ b/.github/workflows/python_pypi_upload.yml
@@ -38,6 +38,6 @@ jobs:
           --outdir dist/
           .
       - name: Publish distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
This change is required due to the sunset of the `master` release of the action.
More information here: https://github.com/pypa/gh-action-pypi-publish#-master-branch-sunset-
