### PR TITLE
MNT: Add vulnerability ignore functionality.

### DIFF
--- a/.github/workflows/docker-scan.yml
+++ b/.github/workflows/docker-scan.yml
@@ -74,6 +74,13 @@ jobs:
       - name: Build Docker image
         run: ${{ inputs.build-command }}
 
+      - name: Create Grype config file to ignore some vulnerabilities (e.g. CVE-2026-22184) which was misclassified
+        run: |
+          cat <<EOF > .grype.yaml
+          ignore:
+            - vulnerability: CVE-2026-22184
+          EOF
+
       - name: Scan Docker image with Anchore (Grype)
         uses: anchore/scan-action@v7
         with:


### PR DESCRIPTION
Adding to remove misclassified CVE which was reduced to Medium severity but is still showing as Critical on scans.

More info:
- https://www.cve.org/cverecord?id=CVE-2026-22184
- https://github.com/madler/zlib/pull/1145