### PR TITLE
ENH: add dynamic ignore-vulnerabilities input to Grype scan in docker-scan.yml

### DIFF
--- a/.github/workflows/docker-scan.yml
+++ b/.github/workflows/docker-scan.yml
@@ -37,6 +37,11 @@ on:
         required: false
         type: string
         default: 'NOT SET'
+      ignore-vulnerabilities:
+        required: false
+        type: string
+        default: ''
+        description: 'Comma-separated list of additional CVE IDs to ignore in Grype scan (e.g. CVE-2023-1234,CVE-2024-5678)'
 
     secrets:
       NEXUS_USERNAME:
@@ -83,12 +88,19 @@ jobs:
           NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
           NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
 
-      - name: Create Grype config file to ignore some vulnerabilities (e.g. CVE-2026-22184) which was misclassified
+      - name: Create Grype config file to ignore vulnerabilities
         run: |
           cat <<EOF > .grype.yaml
           ignore:
             - vulnerability: CVE-2026-22184
           EOF
+          if [ -n "${{ inputs.ignore-vulnerabilities }}" ]; then
+            IFS=',' read -ra CVES <<< "${{ inputs.ignore-vulnerabilities }}"
+            for cve in "${CVES[@]}"; do
+              cve=$(echo "$cve" | xargs)
+              echo "  - vulnerability: $cve" >> .grype.yaml
+            done
+          fi
 
       - name: Scan Docker image with Anchore (Grype)
         uses: anchore/scan-action@v7

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To facilitate the implementation of workflows shared by all botcity projects, it
 | **python_ci**          | python   | list_os_name, list_python_version                                                     |                | Run tests in pytest                         |
 | **python_linter**      | python   | flake8, mypy, list_os_name, list_python_version, docstring, docstring_convention      |                | Run flake8, mypy and flake8-docstring.      |
 | **python_pypi_upload** | python   |                                                                                       | PYPI_API_TOKEN | Build package and publish in pypi           |
-| **docker-scan**        | docker   | docker-file, docker-image, build-command, with-maven, java-version, java-distribution |                | Run Docker vulnerability check using Grype. |
+| **docker-scan**        | docker   | docker-file, docker-image, build-command, with-maven, java-version, java-distribution, with-aws-login, aws-region, aws-ecr-registry, ignore-vulnerabilities |                | Run Docker vulnerability check using Grype. |
 
 
 ## Using reusable workflows example
@@ -101,6 +101,59 @@ jobs:
           folder: "botcity"
           docstring: true
           docstring_convention: "google"
+```
+
+### Docker
+#### docker-scan
+
+Using values default:
+
+```yml
+name: docker-scan
+
+on:
+  pull_request:
+  schedule:
+    - cron: '0 8 * * 1'
+
+jobs:
+  scan:
+    uses: botcity-dev/botcity-reusable-workflows/.github/workflows/docker-scan.yml@latest
+    with:
+      docker-image: my-image:latest
+      build-command: docker build -t my-image:latest .
+```
+
+Using passing the arguments:
+
+| Name                    | Description                                                                 | Default         | Required |
+| ----------------------- | --------------------------------------------------------------------------- | --------------- | -------- |
+| docker-file             | Dockerfile path                                                             | `Dockerfile`    | false    |
+| docker-image            | Docker image name to scan                                                   |                 | **true** |
+| build-command           | Command to build the Docker image                                           |                 | **true** |
+| with-maven              | Whether to set up JDK/Maven before building                                 | `false`         | false    |
+| java-version            | Java version to use (requires `with-maven: true`)                           | `21`            | false    |
+| java-distribution       | Java distribution to use (requires `with-maven: true`)                      | `temurin`       | false    |
+| with-aws-login          | Whether to authenticate with AWS ECR before building                        | `false`         | false    |
+| aws-region              | AWS region (requires `with-aws-login: true`)                                | `us-east-1`     | false    |
+| aws-ecr-registry        | AWS ECR registry URL (requires `with-aws-login: true`)                      | `NOT SET`       | false    |
+| ignore-vulnerabilities  | Comma-separated list of additional CVE IDs to ignore. `CVE-2026-22184` is always ignored by default. | `''` | false    |
+
+```yml
+name: docker-scan
+
+on:
+  pull_request:
+  schedule:
+    - cron: '0 8 * * 1'
+
+jobs:
+  scan:
+    uses: botcity-dev/botcity-reusable-workflows/.github/workflows/docker-scan.yml@latest
+    with:
+      docker-image: my-image:latest
+      build-command: docker build -t my-image:latest .
+      ignore-vulnerabilities: 'CVE-2023-1234,CVE-2024-5678'
 ```
 
 #### Pypi upload


### PR DESCRIPTION
## What changed

Added a new optional input `ignore-vulnerabilities` to the `docker-scan` reusable workflow, allowing callers to pass additional CVE IDs to be ignored by Grype at scan time.

`CVE-2026-22184` remains hardcoded in the `.grype.yaml` config and is always ignored regardless of the input.

## How to use

```yml
jobs:
  scan:
    uses: botcity-dev/botcity-reusable-workflows/.github/workflows/docker-scan.yml@latest
    with:
      docker-image: my-image:latest
      build-command: docker build -t my-image:latest .
      ignore-vulnerabilities: 'CVE-2023-1234,CVE-2024-5678'
```

## Files changed
- `.github/workflows/docker-scan.yml` — new input + dynamic `.grype.yaml` generation
- `README.md` — full `docker-scan` section with input table and usage examples