### PR TITLE
enh: add CVE-2026-7210

### DIFF
--- a/.github/workflows/docker-scan.yml
+++ b/.github/workflows/docker-scan.yml
@@ -88,6 +88,7 @@ jobs:
           cat <<EOF > .grype.yaml
           ignore:
             - vulnerability: CVE-2026-22184
+            - vulnerability: CVE-2026-7210
           EOF
 
       - name: Scan Docker image with Anchore (Grype)


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>Description</h2>
<p>Adds <code>CVE-2026-7210</code> to the ignored vulnerabilities list in the Grype configuration (<code>.grype.yaml</code>).</p>
<h2>Context</h2>
<p>During the Docker image vulnerability scan, Grype flagged the following CVE:</p>

CVE | Severity | Affected Package | EPSS
-- | -- | -- | --
CVE-2026-7210 | Critical | python 3.13.13, 3.15.0b2 (binary) | < 0.1% (25th) / < 0.1


<h2>Reason for ignoring</h2>
<p>Although rated <strong>Critical</strong>, the actual exploitation probability is extremely low (EPSS &lt; 0.1%, below the 25th percentile).</p>
<p>The primary reason for keeping the current Python versions and ignoring this CVE is <strong>API compatibility</strong>: upgrading to a patched version would break compatibility with critical project dependencies that do not yet support the Python versions where the fix is available.</p>
<p>This is a conscious and temporary decision, to be revisited once the affected dependencies are updated and compatibility is established.</p>
<h2>Changes</h2>
<ul>
<li><code>docker-scan.yml</code>: adds <code>CVE-2026-7210</code> to the <code>ignore</code> block of the <code>.grype.yaml</code> generated in the Grype configuration step.</li>
</ul></body></html><!--EndFragment-->
</body>
</html>